### PR TITLE
Add net451 target back to MusicStore project.json

### DIFF
--- a/samples/MusicStore/project.json
+++ b/samples/MusicStore/project.json
@@ -33,10 +33,6 @@
     ]
   },
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.1.0",
-      "type": "platform"
-    },
     "Microsoft.AspNetCore": "1.1.0",
     "Microsoft.AspNetCore.Authentication.Cookies": "1.1.0",
     "Microsoft.AspNetCore.Authentication.Facebook": "1.1.0",
@@ -64,12 +60,14 @@
   },
   "frameworks": {
     "netcoreapp1.1": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
-    }
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.1.0-*",
+          "type": "platform"
+        }
+      }
+    },
+    "net451": {}
   },
   "tools": {
     "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.1.0-preview4-final"


### PR DESCRIPTION
This was removed in https://github.com/redhat-developer/s2i-aspnet-musicstore-ex/commit/47b92080b6efc323a6e346ab57440aeee57bcabe#diff-cef6bb18042f24eeb514252fac777063L55, probably to workaround https://github.com/redhat-developer/s2i-dotnetcore/pull/38