### PR TITLE
Set DOTNET_ASSEMBLY_NAME to be able to use samples/MusicStore as context-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ The MusicStore demo should now be runing on [http://127.0.0.1:8080]()
 
 ## Run on OpenShift Origin
 
+### Environment
+
+The `samples/MusicStore` includes a `.s2i/environment` file to control the s2i build.
+
+`project.json` will by default name an assembly the same as the parent folder. If we do a s2i build using `samples/MusicStore` as the `context-dir`, the assembly will be named `src.dll`.
+The `MusicStore` application requires the name to be `MusicStore` because it is using the `WebHostBuilder.UseStartup("MusicStore")` in `Program.cs`. By setting the `DOTNET_ASSEMBLY_NAME` in `.s2i/environment` to `MusicStore`,
+the default `project.json` assembly name will be `MusicStore.dll`.
+
 ### OpenShift Web Console
 
 TODO: aspnet-pgsql-persistent template

--- a/samples/MusicStore/.s2i/environment
+++ b/samples/MusicStore/.s2i/environment
@@ -1,0 +1,1 @@
+DOTNET_ASSEMBLY_NAME=MusicStore


### PR DESCRIPTION
Requires https://github.com/redhat-developer/s2i-dotnetcore/pull/42